### PR TITLE
Add archive.org to the blacklist

### DIFF
--- a/background.js
+++ b/background.js
@@ -23,6 +23,7 @@ const ICON_WHITELIST = "icon-whitelist.svg";
 const MAX_NOTIFICATION_URL_LENGTH = 100;
 
 const GLOBAL_BLACKLIST = [
+    "archive\.org",
     "/abp",
     "/account",
     "/adfs",


### PR DESCRIPTION
Somebody who clicks a link to the archive.org web archive almost
certainly wants to see the old version of the page, and not the
current.

For example the link

https://web.archive.org/web/20190401014912/https://en.wikipedia.org/wiki/Main_Page

should not be redirected to

https://en.wikipedia.org/wiki/Main_Page