### PR TITLE
add: /unauthenticated to blacklist

### DIFF
--- a/background.js
+++ b/background.js
@@ -45,6 +45,7 @@ const GLOBAL_BLACKLIST = [
     "/signup",
     "/sso",
     "/subscribe",
+    "/unauthenticated",
     "/verification",
 ];
 


### PR DESCRIPTION
/unauthenticated is used in ZenDesk when you are not logged in.
The current behavior use the `return_to` parameter and skip the "redirection" meaning you get a redirecting loop between the page you want and the login page which gets skipped.

Signed-off-by: Mathis Raguin <mathis@cri.epita.fr>