### PR TITLE
Add /openid to no skip list

### DIFF
--- a/background.js
+++ b/background.js
@@ -55,6 +55,7 @@ const DEFAULT_NO_SKIP_URLS_LIST = [
     "/logon",
     "/logout",
     "/oauth",
+    "/openid",
     "/preferences",
     "/profile",
     "/register",


### PR DESCRIPTION
An example is the login page of [Fedora Copr](https://copr.fedorainfracloud.org/). But it may be generally used elsewhere.