### PR TITLE
exclude all http methods other than GET

### DIFF
--- a/background.js
+++ b/background.js
@@ -353,7 +353,7 @@ function disableSkipping() {
 }
 
 function maybeRedirect(requestDetails) {
-    if (requestDetails.tabId === -1 || requestDetails.method === "POST") {
+    if (requestDetails.tabId === -1 || requestDetails.method !== "GET") {
         return;
     }
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods

We should exclude more HTTP methods