### PR TITLE
no skip urls list - add firefox portal detection url

### DIFF
--- a/background.js
+++ b/background.js
@@ -72,6 +72,7 @@ const DEFAULT_NO_SKIP_URLS_LIST = [
     "/subscribe",
     "/unauthenticated",
     "/verification",
+    "detectportal.firefox.com/canonical.html"
 ];
 
 let currentMode = undefined;


### PR DESCRIPTION
This PR adds the firefox [captive portal detection](https://support.mozilla.org/en-US/kb/captive-portal) redirect URL to the no-skip list. 

**Problem:** currently, wifi redirect pages that use the Firefox captive portal URL in a parameter are redirected by the extension, breaking the captive portal login in many cases.