### PR TITLE
Add /eid-client to default no-skip-url-list in background.js

### DIFF
--- a/background.js
+++ b/background.js
@@ -52,6 +52,7 @@ const DEFAULT_NO_SKIP_URLS_LIST = [
     "/auth",
     "/cookie",
     "/download",
+    "/eid-client"
     "/login",
     "/logoff",
     "/logon",


### PR DESCRIPTION
Added /eid-client to the default no-skip-url-list in background.js to skip redirects to the "AusweisApp" (https://github.com/Governikus/AusweisApp) which is the official eID-Client of the German government. Like mentioned in https://www.ausweisapp.bund.de/fuer-diensteanbieter/leitfaden/technische-hinweise, the redirects used are "http://127.0.0.1:24727/eID-Client" on computers or "eid://127.0.0.1:24727/eID-Client" on mobile phones. So the added parameter should work for both. Only tested with Firefox on a computer, because the addon is not available for Firefox mobile.